### PR TITLE
サンプルコードのコンパイルエラーが逆になっている

### DIFF
--- a/episodes/Swift Taskのイニシャライザとselfの関係.md
+++ b/episodes/Swift Taskのイニシャライザとselfの関係.md
@@ -120,8 +120,8 @@ final class SomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         Task {
-            globalActorFunction() // ⭕️
-            mainActorFunction() // ❌ Expression is 'async' but is not marked with 'await'
+            globalActorFunction() // ❌ Expression is 'async' but is not marked with 'await'
+            mainActorFunction() // ⭕️
         }
     }
 }


### PR DESCRIPTION
該当箇所、下記のことが言いたいと思うのですが

- globalActorFunctionはMainActorでないのでawaitがないとコンパイルエラー
- mainActorFunctionはfuncなのでawaitする必要がない

サンプルコードが逆になってるように思えます。